### PR TITLE
Add support for GPT-5.2 models

### DIFF
--- a/app/config/ai.ts
+++ b/app/config/ai.ts
@@ -85,6 +85,8 @@ export const defaultConversationConfig = {
 
 export const modelSuggestions = {
   openai: [
+    "gpt-5.2",
+    "gpt-5.2-mini",
     "gpt-4o",
     "gpt-4o-mini",
     "gpt-4.1-2025-04-14",

--- a/app/routes/api/ai/chat.ts
+++ b/app/routes/api/ai/chat.ts
@@ -40,6 +40,8 @@ function getProviderOptionsForAISDK(
     "gemini-2.5-pro",
   ];
 
+  const openaiModelsWithThinkingOff = ["gpt-5.2", "gpt-5.2-mini"];
+
   if (provider === "google" && specificGoogleModels.includes(model)) {
     return {
       google: {
@@ -49,6 +51,15 @@ function getProviderOptionsForAISDK(
       },
     };
   }
+
+  if (provider === "openai" && openaiModelsWithThinkingOff.includes(model)) {
+    return {
+      openai: {
+        reasoningEffort: "none",
+      },
+    };
+  }
+
   return undefined;
 }
 


### PR DESCRIPTION
## Summary
- Add `gpt-5.2` and `gpt-5.2-mini` to the OpenAI model suggestions
- Disable thinking/reasoning for GPT-5.2 models via `reasoningEffort: "none"`

## Test plan
- [ ] Verify GPT-5.2 models appear in the model selector
- [ ] Test chat completion with GPT-5.2 models
- [ ] Confirm reasoning is disabled in API requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)