### PR TITLE
Fix GPT-5.2 max_tokens parameter

### DIFF
--- a/app/config/ai.ts
+++ b/app/config/ai.ts
@@ -87,7 +87,6 @@ export const modelSuggestions = {
   openai: [
     "gpt-5.2",
     "gpt-5.2-mini",
-    "gpt-5.2-instant",
     "gpt-4o",
     "gpt-4o-mini",
     "gpt-4.1-2025-04-14",


### PR DESCRIPTION
## Summary
- Fix GPT-5.2 API error by using `max_completion_tokens` instead of `max_tokens`
- Remove `gpt-5.2-instant` from model suggestions (not a valid model)

## Details
GPT-5.2 models return a 400 error when `max_tokens` is passed. OpenAI requires `max_completion_tokens` for these models instead. This PR:
1. Passes `maxCompletionTokens` via `providerOptions.openai` for GPT-5.2 models
2. Omits the standard `maxTokens` parameter for these models

## Test plan
- [ ] Test GPT-5.2 model requests work without 400 errors
- [ ] Test GPT-5.2-mini model requests work without 400 errors
- [ ] Verify other models (GPT-4o, Claude, Gemini) still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)